### PR TITLE
Fix docs for removed router module

### DIFF
--- a/structure.txt
+++ b/structure.txt
@@ -1,8 +1,7 @@
 tweet_eval_agent/
 ├── main.py                          # Punto de entrada de la API (FastAPI)
 ├── agent/
-│   ├── graph.py                     # LangGraph: conexión entre nodos
-│   ├── router.py                    # Detecta la intención y enruta
+│   ├── graph.py                     # Grafo LangGraph que enruta segun intencion
 │   ├── nodes/
 │   │   ├── predictor.py             # Nodo para predicción de sentimiento
 │   │   ├── evaluator.py             # Nodo para devolver métricas


### PR DESCRIPTION
## Summary
- update `structure.txt` to remove outdated `router.py` entry
- clarify that `graph.py` performs routing
- add newline at EOF

## Testing
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_685c2cf3bdbc832ea2371705c3ca9a31