### PR TITLE
Switch tweet text extraction to Claude

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -5,7 +5,7 @@ from agent.nodes.predictor import predict_sentiment
 from agent.nodes.evaluator import get_model_metrics
 from agent.nodes.visualizer import get_confusion_matrix
 from agent.nodes.responder import generate_response
-from agent.utils.helpers import detect_intent_claude, extract_text_from_question
+from agent.utils.helpers import detect_intent_claude, extract_text_from_question_claude
 
 # Nodo que decide la intención
 def agent_node_router(state):
@@ -16,7 +16,7 @@ def agent_node_router(state):
 
 # Nodo de predicción
 def prediction_node(state):
-    text = extract_text_from_question(state["question"])
+    text = extract_text_from_question_claude(state["question"])
     result = predict_sentiment(text)
     state["result"] = result
     return state

--- a/agent/utils/helpers.py
+++ b/agent/utils/helpers.py
@@ -55,3 +55,22 @@ def extract_text_from_question(question: str):
     """
     match = re.search(r'"([^"]+)"|\'([^\']+)\'', question)
     return match.group(1) or match.group(2) if match else question
+
+
+def extract_text_from_question_claude(question: str) -> str:
+    """Extrae el texto de la pregunta usando un modelo de Anthropic."""
+    client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+
+    prompt = (
+        "A partir de la siguiente pregunta, devuelve solo el texto del tweet referido, si existe. "
+        "Si no se identifica ningún tweet, devuelve la pregunta tal cual.\n\n"
+        f"Pregunta: {question}"
+    )
+
+    response = client.messages.create(
+        model="claude-3-5-sonnet-20241022",
+        max_tokens=100,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    return response.content[0].text.strip()


### PR DESCRIPTION
## Summary
- call new Claude-based function to parse the tweet from the question
- implement `extract_text_from_question_claude` using Anthropic

## Testing
- `python -m py_compile main.py agent/graph.py agent/utils/helpers.py`
- `pytest` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_685c60e9cc70832e84d879905758ccd3