### PR TITLE
Add graceful exit in agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ python main.py
 ```
 
 Then POST questions to `http://localhost:8000/ask` with a JSON payload `{"question": "<your question>"}`.
+If the question is `"salir"` or `"no"` the service will return a farewell and no further processing will occur.

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -81,5 +81,9 @@ agent_graph = build_agent_graph()
 
 def process_question(question: str) -> str:
     """Función pública que recibe una pregunta y devuelve la respuesta final."""
+    normalized = question.strip().lower()
+    if normalized in {"salir", "no"}:
+        return "Conversación finalizada. ¡Hasta luego!"
+
     result = agent_graph.invoke({"question": question})
     return result.get("response")

--- a/test_agent.py
+++ b/test_agent.py
@@ -16,3 +16,4 @@ if __name__ == "__main__":
     test_query("¿Cuáles son las métricas del modelo finetuned?")
     test_query("Muéstrame la matriz de confusión del modelo fine-tuned.")
     test_query("Hola, ¿cómo estás?")
+    test_query("salir")  # Debería finalizar la conversación

--- a/test_api.py
+++ b/test_api.py
@@ -6,7 +6,8 @@ questions = [
     "¿Qué sentimiento tiene el siguiente texto? 'Me encanta este producto, es increíble.'",
     "¿Cuáles son las métricas del modelo finetuned?",
     "Muéstrame la matriz de confusión del modelo fine-tuned.",
-    "Hola, ¿cómo estás?"  # Desconocido
+    "Hola, ¿cómo estás?",  # Desconocido
+    "salir"
 ]
 
 for q in questions:


### PR DESCRIPTION
## Summary
- handle "salir" and "no" directly in `process_question`
- document new behaviour in README
- extend example scripts with an exit case

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_685c779f8398832e90fdc9e391bb6e13