### PR TITLE
Add follow-up prompt in agent responses

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -36,13 +36,16 @@ def conf_matrix_node(state):
 # Nodo de respuesta con LLM o mensaje fijo para intent unknown
 def responder_node(state):
     if state.get("intent") == "unknown":
-        state["response"] = "Lo siento, no entiendo esa pregunta; ¿puedes reformularla?"
+        state["response"] = (
+            "Lo siento, no entiendo esa pregunta; ¿puedes reformularla?"
+            "\n\n¿Tienes otra pregunta?"
+        )
         return state
 
     question = state["question"]
     result = state["result"]
     response = generate_response(question, str(result))
-    state["response"] = response
+    state["response"] = response + "\n\n¿Tienes otra pregunta?"
     return state
 
 # Construcción del grafo

--- a/agent/nodes/responder.py
+++ b/agent/nodes/responder.py
@@ -37,7 +37,10 @@ def responder_node(state):
     - Si no, tratar de generar respuesta con Claude y capturar errores.
     """
     if state.get("intent") == "unknown":
-        state["response"] = "Lo siento, no entiendo esa pregunta; ¿puedes reformularla?"
+        state["response"] = (
+            "Lo siento, no entiendo esa pregunta; ¿puedes reformularla?"
+            "\n\n¿Tienes otra pregunta?"
+        )
         return state
 
     question = state["question"]
@@ -65,5 +68,5 @@ def responder_node(state):
         else:
             response = f"Error al generar la respuesta con Claude: {err}"
     
-    state["response"] = response
+    state["response"] = response + "\n\n¿Tienes otra pregunta?"
     return state


### PR DESCRIPTION
## Summary
- tweak graph responder node so all answers include a follow-up prompt
- mirror the same behavior in `agent/nodes/responder.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685c78775e24832eaced5b4faf107eba