### PR TITLE
Update README usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,10 @@ python main.py
 ```
 
 Then POST questions to `http://localhost:8000/ask` with a JSON payload `{"question": "<your question>"}`.
-If the question is `"salir"` or `"no"` the service will return a farewell and no further processing will occur.
+
+Send `"salir"` or `"no"` to end the interaction at any time. Any other
+response from the API will conclude with the phrase
+`"¿Tienes otra pregunta?"` so that you can continue the conversation.
+
+Clients may implement their own inactivity timer of around twenty seconds to
+close the session if the user stops sending questions.


### PR DESCRIPTION
## Summary
- document ending conversation with `salir` or `no`
- clarify response ending and optional inactivity timeout

## Testing
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_685c79715f14832e873da3e60970cff1