### PR TITLE
Exclude accuracy metrics

### DIFF
--- a/agent/nodes/evaluator.py
+++ b/agent/nodes/evaluator.py
@@ -3,6 +3,8 @@ from agent.utils.loader import load_metrics
 
 def get_model_metrics():
     df = load_metrics()
-    df = df.loc[["accuracy", "macro avg", "weighted avg"]]
+    # Keep only the aggregate rows that contain the true model metrics
+    df = df.loc[["macro avg", "weighted avg"]]
     # Convertir DataFrame a estructura dict completamente compatible
-    return {row: df.loc[row].to_dict() for row in df.index}
+    # Rename keys replacing spaces with underscores (e.g. "macro avg" -> "macro_avg")
+    return {row.replace(" ", "_"): df.loc[row].to_dict() for row in df.index}


### PR DESCRIPTION
## Summary
- only provide macro and weighted metrics in the evaluator
- clarify the rows contain the model metrics and rename the keys

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862589a9cd8832ea94187f594e72a53